### PR TITLE
token auth instead

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -161,12 +161,12 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ),
 }
 
-REST_USE_JWT = True
+
 
 CORS_ALLOW_ALL_ORIGINS = env.bool("ALLOW_ALL_ORIGINS")


### PR DESCRIPTION
- Switch to token auth instead
- api/login/ returns a 'key' now
- use keyword 'Token' in auth headers